### PR TITLE
feat: add ability to define custom html templates

### DIFF
--- a/lib/config/configBlocks/props.txt
+++ b/lib/config/configBlocks/props.txt
@@ -19,3 +19,5 @@
     quiet: false,
     // Set a name for the browser window
     name: '$$name$$',
+    // A optional template to use
+    template: undefined,

--- a/lib/config/mergeConfig.mjs
+++ b/lib/config/mergeConfig.mjs
@@ -17,6 +17,7 @@
  * @property { boolean } [quiet] - flag indicating if logs should be suppressed.
  * @property { boolean } [verbose] - flag indicating if extended logs should be sent to the console. Will log
  * all HTTP requests done by byndly.
+ * @property { string } [template] - path to a html file or html string
  */
 
 const defaultConfig = {
@@ -30,6 +31,7 @@ const defaultConfig = {
     bootstrap: undefined,
     include: undefined,
     bundle: undefined,
+    template: undefined,
 };
 
 const ARGS_DICT = {
@@ -40,6 +42,7 @@ const ARGS_DICT = {
     v: 'verbose',
     m: 'module',
     b: 'bundle',
+    t: 'template',
 };
 
 /** @todo: Assert that the passed configuration via flags is correctly using long and short flags */

--- a/lib/http/createTemplate.mjs
+++ b/lib/http/createTemplate.mjs
@@ -41,14 +41,26 @@ const createIncludes = (includes) => {
     return links.join('\n');
 };
 
+const handleHTMLInclude = async (string) => {
+    if (!string) return '';
+
+    const lcs = string.toLocaleLowerCase();
+    if (lcs.endsWith('.html')) {
+        return await fs.readFile(resolve(dirname(fileURLToPath(import.meta.url)), string), 'utf-8');
+    }
+
+    return string;
+};
+
 /**
  *
  * @param { import("../config/default.config.mjs").UserConfig } config
  */
 
 export const createTemplate = async (config) => {
-    const { include, bundle, name, module, port, host, bootstrap, watch } = config;
+    const { include, bundle, name, module, port, host, bootstrap, watch, template: htmlInclude } = config;
     const template = await fs.readFile(resolve(dirname(fileURLToPath(import.meta.url)), './template.html'), 'utf-8');
+    const htmlToInsert = await handleHTMLInclude(htmlInclude);
     const createRegex = (val) => new RegExp(`\\\$\\\$${val}\\\$\\\$`, 'gim');
     return template
         .replace(createRegex('name'), (r) => name)
@@ -59,5 +71,6 @@ export const createTemplate = async (config) => {
         .replace(createRegex('scriptType'), (r) => (module ? 'type="module"' : ''))
         .replace(createRegex('module'), (r) => (module && bootstrap ? createModuleScript(bundle, bootstrap) : ''))
         .replace(createRegex('bootstrap'), (r) => (!module && bootstrap ? createGlobalScript(bootstrap) : ''))
-        .replace(createRegex('include'), (r) => (include ? createIncludes(include) : ''));
+        .replace(createRegex('include'), (r) => (include ? createIncludes(include) : ''))
+        .replace(createRegex('body'), (r) => (htmlInclude ? htmlToInsert : ''));
 };

--- a/lib/http/template.html
+++ b/lib/http/template.html
@@ -15,5 +15,7 @@
         <!-- Script to listen for reload events by the server -->
         $$watch$$
     </head>
-    <body></body>
+    <body>
+        $$body$$
+    </body>
 </html>

--- a/lib/types/index.d.ts
+++ b/lib/types/index.d.ts
@@ -68,4 +68,11 @@ export type UserConfig = {
      * calling byndly. Currently additional logs consist of requests and reloads.
      */
     verbose?: boolean;
+    /**
+     * @type { string }
+     * @description
+     * A optional string indicating a path to a HTML file or a html string, that will
+     * be inserted into the body of the created template.
+     */
+    template?: string;
 };

--- a/readme.md
+++ b/readme.md
@@ -200,6 +200,13 @@ export default {
 // the css file will be included as stylesheet client side, the js file will be included as script.
 ```
 
+#### **template**
+
+Type: `string`  
+CLI: `--t/--template/--template=<path>`
+
+A optional string indicating a path to a HTML file or a html string, that will be inserted into the body of the created template. This can be used to quickly setup a DOM testing suite or elements needed to test or work on the library.
+
 ### Typescript support
 
 Byndly does not have a publicly accessible API and is not meant to be used through the API. However, types exist for the configuration object. They're mostly meant for editor autocompletion via JSDocs, as your config file should not be bundled or transpiled with the rest of your code. As such, Byndly does not support TypeScript config files. Below you can find an extensive example with explanations how a config file might look when used with types.
@@ -240,6 +247,8 @@ export default {
     quiet: false,
     // set a name for the browser window
     name: 'Development setup via Byndly.',
+    // create a div with id 'app' for testing
+    template: '<div id="app"></div>',
 };
 ```
 

--- a/readme.md
+++ b/readme.md
@@ -200,7 +200,7 @@ export default {
 // the css file will be included as stylesheet client side, the js file will be included as script.
 ```
 
-#### **template**
+#### **`template`**
 
 Type: `string`  
 CLI: `--t/--template/--template=<path>`


### PR DESCRIPTION
This PR adds the ability to provide a custom HTML Template string that is inserted into the body, enabling quickly prototyping libraries that rely on DOM elements, without the need to add them in the bootstrap function.